### PR TITLE
FIX: do not return duplicates from /polls/voters.json

### DIFF
--- a/plugins/poll/lib/poll.rb
+++ b/plugins/poll/lib/poll.rb
@@ -223,7 +223,7 @@ class DiscoursePoll::Poll
     offset = (page - 1) * limit
 
     params = {
-      offset: offset,
+      offset: offset + 1,
       offset_plus_limit: offset + limit,
       option_digest: opts[:option_id].presence,
     }


### PR DESCRIPTION
When doing paginated requests to /polls/voters.json, each
page after the first contained an extra voter - the last one from
the previous page.

c.f. https://meta.discourse.org/t/polls-voters-json-returning-duplicate-users-across-paged-requests/376636
